### PR TITLE
Bugfix in result.php: fixes ineffective check of reCAPTCHA response

### DIFF
--- a/result.php
+++ b/result.php
@@ -1,15 +1,6 @@
 <?php
 include('header.php');
 
-$url     = yourls_sanitize_url( $_REQUEST['url'] );
-$keyword = isset( $_REQUEST['keyword'] ) ? yourls_sanitize_keyword( $_REQUEST['keyword'] ): '' ;
-$title   = isset( $_REQUEST['title'] ) ? yourls_sanitize_title( $_REQUEST['title'] ) : '' ;
-$return  = yourls_add_new_link( $url, $keyword, $title );
-		
-$shorturl = isset( $return['shorturl'] ) ? $return['shorturl'] : '';
-$message  = isset( $return['message'] ) ? $return['message'] : '';
-$title    = isset( $return['title'] ) ? $return['title'] : '';
-
 $resp = recaptcha_check_answer (ISQ::$recaptcha['private'],
 								$_SERVER["REMOTE_ADDR"],
 								$_POST["recaptcha_challenge_field"],
@@ -20,6 +11,14 @@ if (!$resp->is_valid) {
 	die ( '<p class="error" title="' . $resp->error . '">' . yourls__( 'The reCAPTCHA wasn\'t entered correctly. Go back and try it again.', 'isq_translation' ) . '</p></div></div>' );
 }
 
+$url     = yourls_sanitize_url( $_REQUEST['url'] );
+$keyword = isset( $_REQUEST['keyword'] ) ? yourls_sanitize_keyword( $_REQUEST['keyword'] ): '' ;
+$title   = isset( $_REQUEST['title'] ) ? yourls_sanitize_title( $_REQUEST['title'] ) : '' ;
+$return  = yourls_add_new_link( $url, $keyword, $title );
+		
+$shorturl = isset( $return['shorturl'] ) ? $return['shorturl'] : '';
+$message  = isset( $return['message'] ) ? $return['message'] : '';
+$title    = isset( $return['title'] ) ? $return['title'] : '';
 ?>
 
 <!-- Error reporting -->


### PR DESCRIPTION
Area: reCAPTCHA response check
Title: Fixes ineffective check of reCAPTCHA response
Threat level: Serious
Author: BestNa.me Labs (http://BestNa.me)
Description: 
a) Problem: In the original code the check for the reCAPTCHA response was ineffective: a short URL gets generated and inserted into the DB even when the reCAPTCHA question was not answered correctly. To reproduce the problem with the original code, please enter a destination URL, but simply leave the reCAPTCHA question unanswered, and then inspect the DB right after the error message 'The reCAPTCHA wasn't entered correctly ...' has been displayed. The short URL will show up in the DB, though. This behavior (behaviour) has been observed and described by other users before.
b) Fix: Moved the call to yourls_add_new_link (and some associated lines of code) BELOW the check of the recaptcha response.